### PR TITLE
set-up-device.md: Clean up curl command

### DIFF
--- a/docs/get-started/set-up-device.md
+++ b/docs/get-started/set-up-device.md
@@ -74,8 +74,8 @@ To get basic device information, such as firmware version and architecture, use 
 http://192.168.0.90/axis-cgi/basicdeviceinfo.cgi
 ```
 To extract the messages, use the CGI from a terminal, using the credentials set in the network configuration:
-```bash
-curl --anyauth "*" -u [username]:[password] 192.168.0.90/axis-cgi/basicdeviceinfo.cgi --data "{\"apiVersion\":\"1.0\",\"context\":\"Client defined request ID\",\"method\":\"getAllProperties\"}"
+```sh
+curl --anyauth '*' -u '[username]:[password]' 192.168.0.90/axis-cgi/basicdeviceinfo.cgi --data '{"apiVersion":"1.0","context":"Client defined request ID","method":"getAllProperties"}'
 ```
 
 The following response contains architecture "Architecture": "armv7hf", and firmware version "Version": "9.50.1":


### PR DESCRIPTION
Make curl command less cluttered while also making its script syntax
somwhat more correct.

- Use single quotes for static strings, not double
- Use quotes for username:password to handle all chars in password
