### PR TITLE
OS nomenclature in "What is ACAP?"

### DIFF
--- a/docs/introduction/what-is-acap.md
+++ b/docs/introduction/what-is-acap.md
@@ -30,7 +30,7 @@ ACAP makes it possible to develop applications for a wide range of applications:
 
 ### ACAP SDK Docker images
 
-From ACAP version 3.1, the SDK format relies on the [Docker](https://www.docker.com/) toolchain, something we see many developers use to manage their software. An important advantage of using Docker is that the SDK can be decoupled from the underlying host operating system. This enables us to support development across all Docker capable platforms, including not only Linux, but also Windows 10 and MacOS X. Docker also offers a rich set of tools to build and ship software.
+From ACAP version 3.1, the SDK format relies on the [Docker](https://www.docker.com/) toolchain, something we see many developers use to manage their software. An important advantage of using Docker is that the SDK can be decoupled from the underlying host operating system. This enables us to support development across all Docker capable platforms, including not only Linux, but also Windows and macOS. Docker also offers a rich set of tools to build and ship software.
 
 If you're new to Docker and its many features, check out their [Getting Started guide](https://www.docker.com/get-started). 
 


### PR DESCRIPTION
- With the release of Windows 11 it's perhaps better to say that *Windows* is supported
- I think the name of the OS is *macOS* and not *MacOS X* ([source](https://en.wikipedia.org/wiki/MacOS))