### PR TITLE
docs: Require signed ACAPs by default

### DIFF
--- a/docs/faq/index.md
+++ b/docs/faq/index.md
@@ -16,9 +16,9 @@ nav_order: 10
 
 ## Sign ACAP applications
 
-Signing an ACAP application, and having the Axis device verify the signature on installation, is currently in development and has not been officially released.
+Signed ACAP applications, and having the Axis device verify the signature on installation, is supported in Axis devices as of AXIS OS 9.2.
 
-In an upcoming [AXIS OS release](https://help.axis.com/axis-os), the Axis device will, using [VAPIX](https://www.axis.com/vapix-library/subjects/t10102231/section/t10036126/display?section=t10036126-t10185050), only accept signed ACAP applications, improving the device's security posture. As of AXIS OS 11.2, this is an opt-in feature, but at some point, the state of only accepting signed ACAP applications will be the default.
+With AXIS OS 11.2 [AXIS OS release](https://help.axis.com/axis-os), an interface was added to [VAPIX](https://www.axis.com/vapix-library/subjects/t10102231/section/t10036126/display?section=t10036126-t10185050) to control whether the device will only accept signed ACAP applications or not, improving the device's security posture. As of AXIS OS 11.2, this is an opt-in feature. For AXIS OS 11.5 and later firmware, the state of only accepting signed ACAP applications becomes the default.
 
 We recommend that you disable this check while developing your ACAP application. Once you are ready to use your application in production, you can sign it using the [ACAP Service Portal](../service-for-partners/acap-service-portal.md).
 

--- a/docs/service/acap-application-signing.md
+++ b/docs/service/acap-application-signing.md
@@ -11,7 +11,7 @@ The sign package service is available in the ACAP Service Portal, and requires T
 
 By signing an ACAP package you make sure that the content of the package is not tampered with between the release and installation on the Axis device.
 
-During the signing process, a signature is added at the end of the application package. The signature is verified by the device when installing the ACAP application.
+During the signing process, a signature is added at the end of the application package. The signature is verified by the device when installing the ACAP application. Signing an application requires the VENDOR field to be set in the [manifest](../develop/application-project-structure#manifest-file-content). This must correspond to the name you are registered with as an [Axis Technology Integration Partner (TIP)](https://www.axis.com/partner/technology-integration-partner-program) otherwise signing will be refused
 
 Support for verifying signed ACAP applications was introduced in firmware 9.20. The format as such is fully backward compatible. A signed ACAP application can be installed on devices with a firmware earlier than 9.20, in which case it’s not verified by the device.
 


### PR DESCRIPTION
Change-Id: I4fdf538b5b6ea290105b233d1a34bc814b41765e

Note that the default for allowing unsigned ACAPs to be installed changes (with AxOS 11.5),
VENDOR field in manifest required for signing, and that it must correspond to that registered as a TIP.