### PR TITLE
docs: add path to generated header in vscode settings

### DIFF
--- a/docs/develop/setting-up-visual-studio-code.md
+++ b/docs/develop/setting-up-visual-studio-code.md
@@ -79,7 +79,7 @@ In `.vscode`, create a `c_cpp_properties.json` with the following content:
                "name": "Linux",
                "includePath": [
                    "${workspaceFolder}/**",
-                   "${SDKTARGETSYSROOT}/usr/include/**"
+                   "${SDKTARGETSYSROOT}/**",
                ]
            }
        ],


### PR DESCRIPTION
Add path to generated headers in vscode settings