### PR TITLE
docs/develop: Replace g_dbus_proxy_call with g_dbus_connection_call

### DIFF
--- a/docs/develop/VAPIX-access-for-ACAP-applications.md
+++ b/docs/develop/VAPIX-access-for-ACAP-applications.md
@@ -53,35 +53,24 @@ An ACAP application can acquire VAPIX service account credentials through a D-Bu
     GDBusConnection *connection = g_bus_get_sync(G_BUS_TYPE_SYSTEM, NULL, &error);
     ```
 
-2. Create a proxy object for your D-Bus interface:
-
-    This proxy allows users to interact with your D-Bus service or interface.
-
-    ```c
-    GDBusProxy *proxy = g_dbus_proxy_new_sync(connection,
-                                                G_DBUS_PROXY_FLAGS_NONE,
-                                                NULL, 
-                                                "com.axis.HTTPConf1",
-                                                "/com/axis/HttpConf1/Auth",
-                                                "com.axis.HTTPConf1.Auth1",
-                                                NULL, 
-                                                &error);
-    ```
-
-3. Invoke the D-Bus method using the proxy:
+2. Invoke the D-Bus method using the D-Bus connection:
 
     The user can effectively call the method that returns the credentials by doing this.
 
     ```c
     GVariant *username = g_variant_new("(s)", "testuser");
 
-    GVariant *result = g_dbus_proxy_call_sync(proxy,
-                                                "com.axis.HTTPConf1.Auth1.GetVapixServiceAccountCredentials",
-                                                username,  
-                                                G_DBUS_CALL_FLAGS_NONE,
-                                                -1,  
-                                                NULL, 
-                                                &error);
+    GVariant *result = g_dbus_connection_call_sync (connection,
+                                                    "com.axis.HTTPConf1",
+                                                    "/com/axis/HttpConf1/Auth",
+                                                    "com.axis.HTTPConf1.Auth1",
+                                                    "GetVapixServiceAccountCredentials",
+                                                    username,
+                                                    NULL,
+                                                    G_DBUS_CALL_FLAGS_NONE,
+                                                    -1,
+                                                    NULL,
+                                                    &error);
     ```
 
     When the `GetVapixServiceAccountCredentials` method is invoked, it generates credentials with the specified username and a random password, which is returned to the ACAP as a string.


### PR DESCRIPTION
### Describe your changes

The example in "VAPIX access for ACAP applications" creates a connection to the bus, creates a proxy object and then calls the method. Creating a proxy for this use-case is unnecessary and does one or more D-Bus calls under the hood as you do not pass G_DBUS_PROXY_FLAGS_DO_NOT_LOAD_PROPERTIES which is necessary to make this request "lightweight". The better solution is to skip the proxy completely and just use g_dbus_connection_call_sync, as we do not use any of the features of the proxy.

### Issue ticket number and link

N/A

### Checklist before requesting a review

- [x] I have performed a self-review of my own code
- [x] I have verified that the code builds perfectly fine on my local system
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have verified that my code follows the style already available in the repository
- [x] I have made corresponding changes to the documentation
