### PR TITLE
fix: Update vapix access sample output

### DIFF
--- a/docs/acap-sdk-version-3/develop-applications/vapix-access-for-acap-applications.md
+++ b/docs/acap-sdk-version-3/develop-applications/vapix-access-for-acap-applications.md
@@ -146,7 +146,7 @@ gdbus call --system
 Example response:
 
 ```bash
-('id:a0-testuser, pass:MH757eGZdsyBuAbhAQ3j2ZtRNg9xchEg',)
+('a0-testuser:MH757eGZdsyBuAbhAQ3j2ZtRNg9xchEg',)
 ```
 
 Make a VAPIX request on local virtual host 127.0.0.12 with the given credentials using `curl`.

--- a/docs/develop/VAPIX-access-for-ACAP-applications.md
+++ b/docs/develop/VAPIX-access-for-ACAP-applications.md
@@ -139,7 +139,7 @@ gdbus call --system
 Example response:
 
 ```bash
-('id:a0-testuser, pass:MH757eGZdsyBuAbhAQ3j2ZtRNg9xchEg',)
+('a0-testuser:MH757eGZdsyBuAbhAQ3j2ZtRNg9xchEg',)
 ```
 
 Make a VAPIX request on local virtual host 127.0.0.12 with the given credentials using `curl`.


### PR DESCRIPTION
I believe the format changed in 11.9 when the feature reached general availability.