### PR TITLE
VAPIX access: Fix incorrect links (#316)

### DIFF
--- a/docs/acap-sdk-version-3/develop-applications/vapix-access-for-acap-applications.md
+++ b/docs/acap-sdk-version-3/develop-applications/vapix-access-for-acap-applications.md
@@ -22,7 +22,7 @@ From AXIS OS 11.6, ACAP applications can acquire VAPIX service account credentia
 >     - to   `('a0-testuser:MH757eGZdsyBuAbhAQ3j2ZtRNg9xchEg',)`
 > - In AXIS OS 11.9 the VAPIX access feature reached General Availability.
 > - Starting from AXIS OS 11.11, an ACAP application user can get SSH access by
->   enabling [Developer Mode](../../get-started/set-up-developer-environment/set-up-device-advanced.md#developer-mode).
+>   enabling [Developer Mode](../../get-started/set-up-developer-environment/set-up-device-advanced#developer-mode).
 
 ## Example application
 
@@ -138,7 +138,7 @@ After obtaining the credentials, it's ready to make the actual VAPIX call. The A
 
 SSH into a device and make a D-Bus call using a command-line to get VAPIX service account credentials.
 
-> - **Note** Starting from AXIS OS 11.11, an ACAP application user can get SSH access by enabling [Developer Mode](../get-started/set-up-developer-environment/set-up-device-advanced#developer-mode).
+> - **Note** Starting from AXIS OS 11.11, an ACAP application user can get SSH access by enabling [Developer Mode](../../get-started/set-up-developer-environment/set-up-device-advanced#developer-mode).
 
 Example call:
 

--- a/docs/develop/VAPIX-access-for-ACAP-applications.md
+++ b/docs/develop/VAPIX-access-for-ACAP-applications.md
@@ -21,7 +21,7 @@ From AXIS OS 11.6, ACAP applications can acquire VAPIX service account credentia
 >     - to   `('a0-testuser:MH757eGZdsyBuAbhAQ3j2ZtRNg9xchEg',)`
 > - In AXIS OS 11.9 the VAPIX access feature reached General Availability.
 > - Starting from AXIS OS 11.11, an ACAP application user can get SSH access by
->   enabling [Developer Mode](../../get-started/set-up-developer-environment/set-up-device-advanced.md#developer-mode).
+>   enabling [Developer Mode](../get-started/set-up-developer-environment/set-up-device-advanced#developer-mode).
 
 ## Example application
 


### PR DESCRIPTION
ACAP 3 and 4 have different relative links.